### PR TITLE
Removes unnecessary crud_push options

### DIFF
--- a/includes/import.form.inc
+++ b/includes/import.form.inc
@@ -293,16 +293,22 @@ function islandora_datastreams_io_analyze_uploaded_zipfile($extract_path, $filen
         islandora_datastreams_io_dump_temp_dir($full_extract_path);
       }
       else {
-        // Determine mimetype
-        $datastreams_mimetype = islandora_datastreams_io_mimetype_of_file($file);
+        // Determine mimetype of existing file and compare to old mimetype
+        $islandora_object = islandora_object_load($ds_fileparts['pid']);
+        $old_mimetype = $islandora_object[$ds_fileparts['dsid']]->mimeType;
+        watchdog('test', 'Old mimetype is ' . $old_mimetype);
+        $new_mimetype = islandora_datastreams_io_mimetype_of_file($file);
+        watchdog('test', 'New mimetype is ' . $new_mimetype);
+        $mimetype_command = ($old_mimetype != $new_mimetype ? " --datastreams_mimetype={$new_mimetype}" : "" ); 
+        watchdog('test', 'Mimetype command is ' . $mimetype_command);
+
         // If datastream label is empty, use this value, else the previous label is used.
         $datastreams_label = 'Imported ' . $dsid;
 
         $this_domain = 'http://' . $_SERVER['HTTP_HOST'];
         $drush_command = 'drush islandora_datastream_crud_push_datastreams -u ' . $user->uid .
                          ' --datastreams_source_directory=' . $full_extract_path .
-                         ' --datastreams_mimetype="' . $datastreams_mimetype . '" ' .
-                         ' --datastreams_label="' . $datastreams_label . '" ' . 
+                         $mimetype_command .
                          ' -y ' .
                          ' --uri=' . $this_domain;
 

--- a/includes/import.form.inc
+++ b/includes/import.form.inc
@@ -296,11 +296,8 @@ function islandora_datastreams_io_analyze_uploaded_zipfile($extract_path, $filen
         // Determine mimetype of existing file and compare to old mimetype
         $islandora_object = islandora_object_load($ds_fileparts['pid']);
         $old_mimetype = $islandora_object[$ds_fileparts['dsid']]->mimeType;
-        watchdog('test', 'Old mimetype is ' . $old_mimetype);
         $new_mimetype = islandora_datastreams_io_mimetype_of_file($file);
-        watchdog('test', 'New mimetype is ' . $new_mimetype);
         $mimetype_command = ($old_mimetype != $new_mimetype ? " --datastreams_mimetype={$new_mimetype}" : "" ); 
-        watchdog('test', 'Mimetype command is ' . $mimetype_command);
 
         // If datastream label is empty, use this value, else the previous label is used.
         $datastreams_label = 'Imported ' . $dsid;


### PR DESCRIPTION
It seems that the options to `islandora_datastream_crud_push` that specify DSID mimetype and label are the culprits in creating new versions of the datastream, and this PR handles their removal.

Specifying DSID label is totally gone, since it was always optional and uses the existing DSID label if not specified, which is the preferred behavior here. 

Since you could theoretically want to change the mimetype of a datastream as part of its replacement, I've added a check to compare the old datastream mimetype to the replacement, and only add the option to update the DSID mimetype if they differ. If they are the same, which they should be for 99% of cases, the option is excluded so another version isn't produced.