### PR TITLE
Fix nonMODS imports

### DIFF
--- a/includes/import.form.inc
+++ b/includes/import.form.inc
@@ -251,6 +251,11 @@ function islandora_datastreams_io_analyze_uploaded_zipfile($extract_path, $filen
                   $cannot_import_reasons[$file] = $ds_fileparts['pid'] . ' failed a schema test';
                 }
               }
+	      else {
+                $files_markup .= 'PID = ' . $ds_fileparts['pid'] .
+                    ', DSID = ' . $ds_fileparts['dsid'] . '<br>';
+                $files_to_import++;
+              }
             }
             else {
               $missing_islandora_objects[] = $ds_fileparts['pid'];

--- a/includes/import.form.inc
+++ b/includes/import.form.inc
@@ -293,16 +293,22 @@ function islandora_datastreams_io_analyze_uploaded_zipfile($extract_path, $filen
         islandora_datastreams_io_dump_temp_dir($full_extract_path);
       }
       else {
-        // Determine mimetype
-        $datastreams_mimetype = islandora_datastreams_io_mimetype_of_file($file);
+        // Determine mimetype of existing file and compare to old mimetype
+        $islandora_object = islandora_object_load($ds_fileparts['pid']);
+        $old_mimetype = $islandora_object[$ds_fileparts['dsid']]->mimeType;
+        watchdog('test', 'Old mimetype is ' . $old_mimetype);
+        $new_mimetype = islandora_datastreams_io_mimetype_of_file($file);
+        watchdog('test', 'New mimetype is ' . $new_mimetype);
+        $mimetype_command = ($old_mimetype != $new_mimetype ? " --datastreams_mimetype={$new_mimetype}" : "" ); 
+        watchdog('test', 'Mimetype command is ' . $mimetype_command);
+
         // If datastream label is empty, use this value, else the previous label is used.
         $datastreams_label = 'Imported ' . $dsid;
 
         $this_domain = 'http://' . $_SERVER['HTTP_HOST'];
         $drush_command = 'drush islandora_datastream_crud_push_datastreams -u ' . $user->uid .
                          ' --datastreams_source_directory=' . $full_extract_path .
-                         ' --datastreams_mimetype="' . $datastreams_mimetype . '" ' .
-                         ' --datastreams_label="' . $datastreams_label . '" ' . 
+                         $mimetype_command .
                          ' -y ' .
                          ' --uri=' . $this_domain;
 

--- a/includes/import.form.inc
+++ b/includes/import.form.inc
@@ -296,11 +296,8 @@ function islandora_datastreams_io_analyze_uploaded_zipfile($extract_path, $filen
         // Determine mimetype of existing file and compare to old mimetype
         $islandora_object = islandora_object_load($ds_fileparts['pid']);
         $old_mimetype = $islandora_object[$ds_fileparts['dsid']]->mimeType;
-        watchdog('test', 'Old mimetype is ' . $old_mimetype);
         $new_mimetype = islandora_datastreams_io_mimetype_of_file($file);
-        watchdog('test', 'New mimetype is ' . $new_mimetype);
         $mimetype_command = ($old_mimetype != $new_mimetype ? " --datastreams_mimetype={$new_mimetype}" : "" ); 
-        watchdog('test', 'Mimetype command is ' . $mimetype_command);
 
         // If datastream label is empty, use this value, else the previous label is used.
         $datastreams_label = 'Imported ' . $dsid;


### PR DESCRIPTION
This PR adds an `else` statement so that datastreams that aren't MODS records can be imported as well.

Prior to this PR, any file with datastreams to be imported that werent MODS would unzip just fine, but the module would claim to find no datastreams to import. I think this might be a bug introduced when features were added for MODS validation. I simply copied the code that fires on a successful MODS validation check, and added it to a an `else` statement so that it does the exact same thing for nonMODS datastreams.

This PR builds off of the code in https://github.com/ulsdevteam/islandora_datastreams_io/pull/9.